### PR TITLE
Fix stray book cover rendered at first position

### DIFF
--- a/src/bookcollection.pas
+++ b/src/bookcollection.pas
@@ -35,7 +35,15 @@ implementation
 { TBookCollection }
 
 procedure TBookCollection.Clear;
+var
+  i : Integer;
+  book : TBook;
 begin
+  for i := mList.Count - 1 downto 0 do
+  begin
+    book := TBook(mList[i]);
+    book.Free;               // free cover controls and the book itself
+  end;
   mList.Clear;
 end;
 

--- a/src/bookcollection.pas
+++ b/src/bookcollection.pas
@@ -32,6 +32,9 @@ end;
 
 implementation
 
+uses
+  unitCoverWorker;
+
 { TBookCollection }
 
 procedure TBookCollection.Clear;
@@ -39,6 +42,7 @@ var
   i : Integer;
   book : TBook;
 begin
+  CoverWorkerStop;
   for i := mList.Count - 1 downto 0 do
   begin
     book := TBook(mList[i]);
@@ -81,6 +85,7 @@ destructor Tbookcollection.Destroy;
 var i:Integer;
     book:TBook;
 begin
+  CoverWorkerStop;
   for i:=0 to mList.Count-1 do
       begin
         book:= (TBook(mList.Items[i]));

--- a/src/unitCoverWorker.pas
+++ b/src/unitCoverWorker.pas
@@ -20,6 +20,9 @@ procedure CoverWorkerEnqueueBookIfMissing(B: TBook);
   queue is empty. Call again later to restart if you enqueue more books. }
 procedure CoverWorkerStart;
 
+{ Stops the background worker and clears any pending books }
+procedure CoverWorkerStop;
+
 implementation
 
 type
@@ -176,6 +179,28 @@ begin
     GWorker := TCoverWorker.Create(True);
     GWorker.FreeOnTerminate := True;
     GWorker.Start;
+  end;
+end;
+
+{ Stops the worker and clears any queued books }
+procedure CoverWorkerStop;
+var
+  l: TList;
+begin
+  if GWorker <> nil then
+  begin
+    GWorker.Terminate;
+    GWorker.WaitFor;
+    GWorker := nil;
+  end;
+  if GPdfQueue <> nil then
+  begin
+    l := GPdfQueue.LockList;
+    try
+      l.Clear;
+    finally
+      GPdfQueue.UnlockList;
+    end;
   end;
 end;
 


### PR DESCRIPTION
## Summary
- free each `TBook` when clearing the collection so stale cover controls are removed

## Testing
- `lazbuild src/myBookShelf.lpi` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b2b968ab8c8320917e6bcab7f98da7