### PR TITLE
Fix StretchDraw calls and add transparent color support

### DIFF
--- a/src/book.pas
+++ b/src/book.pas
@@ -6,7 +6,7 @@ interface
 
 uses
   Classes, SysUtils, Graphics, ExtCtrls, Controls, LCLIntf, LResources, Process,
-  Math, IntfGraphics, FPImage, LazCanvas, FileUtil, LazJPG;
+  Math, IntfGraphics, FPImage, GraphType, LazCanvas, FileUtil, LazJPG;
 
 
 type
@@ -124,7 +124,7 @@ begin
           dstH := Round(Pic.Height * scale);
           offX := (W - dstW) div 2;
           offY := (H - dstH) div 2;
-          Canvas.StretchDraw(Rect(offX, offY, offX + dstW, offY + dstH), Pic.Graphic);
+          Canvas.StretchDraw(offX, offY, dstW, dstH, Pic.Graphic);
         end;
         Png.Assign(Img);
         Png.SaveToFile(Result);
@@ -211,7 +211,7 @@ begin
           dstH := Round(Pic.Height * scale);
           offX := (W - dstW) div 2;
           offY := (H - dstH) div 2;
-          Canvas.StretchDraw(Rect(offX, offY, offX + dstW, offY + dstH), Pic.Graphic);
+          Canvas.StretchDraw(offX, offY, dstW, dstH, Pic.Graphic);
         end;
 
         // No runtime scaling anymore; we drew at target size

--- a/src/unitCoverWorker.pas
+++ b/src/unitCoverWorker.pas
@@ -6,7 +6,7 @@ interface
 
 uses
   Classes, SysUtils, Process, LCLIntf, Graphics, Math, LazJpeg,
-  IntfGraphics, FPImage, LazCanvas,
+  IntfGraphics, FPImage, GraphType, LazCanvas,
   Book, BookCollection, FileUtil;
 
 { Call this once after loading your data: it scans the list and enqueues
@@ -116,7 +116,7 @@ begin
           dstH := Round(Pic.Height * scale);
           offX := (W - dstW) div 2;
           offY := (H - dstH) div 2;
-          Canvas.StretchDraw(Rect(offX, offY, offX + dstW, offY + dstH), Pic.Graphic);
+          Canvas.StretchDraw(offX, offY, dstW, dstH, Pic.Graphic);
         end;
         Png.Assign(Img);
         Png.SaveToFile(Result);


### PR DESCRIPTION
## Summary
- Import `GraphType` for `colTransparent` usage
- Replace outdated `StretchDraw` rect calls with parameter-based calls

## Testing
- `lazbuild --version` *(fails: command not found)*
- `apt-get update` *(fails: The repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_b_68b2c9d984c88320ac6fd1c78e737e98