### PR TITLE
Prevent exceptions when copying new books

### DIFF
--- a/src/main.pas
+++ b/src/main.pas
@@ -340,7 +340,16 @@ begin
         fname := fname + ext;
       end;
       dest := IncludeTrailingPathDelimiter(booksDir) + fname;
-      CopyFile(src, dest);
+      // Skip copy if source already resides in booksDir and avoid exceptions on failure
+      if CompareFilenames(src, dest) <> 0 then
+      begin
+        try
+          CopyFile(src, dest);
+        except
+          // fall back to original path if copy fails for any reason
+          dest := src;
+        end;
+      end;
     end;
 
     book:=TBook.Create(PanelBackground);


### PR DESCRIPTION
## Summary
- avoid copying a book onto itself and catch copy failures

## Testing
- `apt-get update` *(fails: repository not signed)*
- `fpc --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b2e5ab4ff08320873dae47f901706c